### PR TITLE
Read stracktrace before db call

### DIFF
--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -47,9 +47,11 @@ defmodule EctoJob.Worker do
       queue.perform(JobQueue.initial_multi(job), job.params)
     rescue
       e ->
+        stacktrace = System.stacktrace()
+
         JobQueue.update_job_to_retrying(repo, job, DateTime.utc_now(), timeout)
 
-        reraise(e, System.stacktrace())
+        reraise(e, stacktrace)
     end
   end
 


### PR DESCRIPTION
# Before fix
 ```
    ** (MatchError) no match of right hand side value: %Ecto.Multi{names: #MapSet<["delete_job_7"]>, operations: [{"delete_job_7", {:changeset, #Ecto.Changeset<action: :delete, changes: %{attempt: 13}, errors: [], data: #DhlEcommerce.JobQueue<>, valid?: true>, []}}]}
    (elixir) lib/keyword.ex:504: Keyword.delete_key/3
   (elixir) lib/keyword.ex:493: Keyword.put/3
    (ecto_sql) lib/ecto/adapters/sql.ex:537: Ecto.Adapters.SQL.execute/5
    (ecto) lib/ecto/repo/queryable.ex:147: Ecto.Repo.Queryable.execute/4
    (ecto_job) lib/ecto_job/job_queue.ex:338: EctoJob.JobQueue.update_job_to_retrying/4
    (ecto_job) lib/ecto_job/worker.ex:50: EctoJob.Worker.run_queue/2
    (ecto_job) lib/ecto_job/worker.ex:34: EctoJob.Worker.do_work/3
    (elixir) lib/task/supervised.ex:88: Task.Supervised.do_apply/2
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
    Function: #Function<1.12746257/0 in EctoJob.Worker.start_link/3>
    Args: []
```

# After

```
    [error] Task #PID<0.3231.0> started from #PID<0.3204.0> terminating
    ** (MatchError) no match of right hand side value: %Ecto.Multi{names: #MapSet<["delete_job_7"]>, operations: [{"delete_job_7", {:changeset, #Ecto.Changeset<action: :delete, changes: %{attempt: 14}, errors: [], data: #DhlEcommerce.JobQueue<>, valid?: true>, []}}]}
    (dhl_ecommerce) lib/dhl_ecommerce/invoices/event_dispatcher_job.ex:25: DhlEcommerce.Invoices.EventDispatcherJob.perform/2
  (dhl_ecommerce) lib/dhl_ecommerce/job_queue.ex:2: DhlEcommerce.JobQueue.do_perform/2
    (sendle_metrics) lib/sendle_metrics.ex:49: SendleMetrics.time/3
     (dhl_ecommerce) lib/dhl_ecommerce/job_queue.ex:2: anonymous fn/3 in DhlEcommerce.JobQueue.perform/2
      (sendle_metrics) lib/sendle_metrics/tracing.ex:16: SendleMetrics.Tracing.trace_named_background_job/2
    (ecto_job) lib/ecto_job/worker.ex:47: EctoJob.Worker.run_queue/2
      (ecto_job) lib/ecto_job/worker.ex:34: EctoJob.Worker.do_work/3
```